### PR TITLE
V0.4.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ botocore>=1.5.7
 Flask>=0.12
 future>=0.16.0
 PyYAML>=3.12
+requests>=2.20.0

--- a/spark_notebook/cloud/aws.py
+++ b/spark_notebook/cloud/aws.py
@@ -378,11 +378,14 @@ class AWS:
         try:
             response = client.describe_security_groups(GroupIds=[security_group_id])
 
-            # Loop through all of the security group permissions and if the port
+            # Loop through all of the security group permissions and if the port and cidr ip is
+            # present return true
             for ip_permission in response["SecurityGroups"][0]["IpPermissions"]:
-                if ip_permission["FromPort"] == port and ip_permission["ToPort"] == port and \
-                        ip_permission["IpRanges"][0]["CidrIp"] == cidr_ip:
-                    return True
+                if ip_permission["FromPort"] == port and ip_permission["ToPort"] == port:
+                    # Find the cidr ip in the list of ip ranges
+                    for ip_range in ip_permission["IpRanges"]:
+                        if ip_range["CidrIp"] == cidr_ip:
+                            return True
             return False
         except botocore.exceptions.ClientError as e:
             raise AWSException("There was an error describing the security group: %s" %

--- a/spark_notebook/cloud/aws.py
+++ b/spark_notebook/cloud/aws.py
@@ -366,7 +366,7 @@ class AWS:
         except Exception as e:
             raise AWSException("Unknown Error: %s" % e)
 
-    def get_security_group_port_open(self, security_group_id, port):
+    def get_security_group_port_open(self, security_group_id, cidr_ip, port):
         try:
             client = boto3.client('ec2',
                                   aws_access_key_id=self.access_key_id,
@@ -380,14 +380,15 @@ class AWS:
 
             # Loop through all of the security group permissions and if the port
             for ip_permission in response["SecurityGroups"][0]["IpPermissions"]:
-                if ip_permission["FromPort"] == port and ip_permission["ToPort"] == port:
+                if ip_permission["FromPort"] == port and ip_permission["ToPort"] == port and \
+                        ip_permission["IpRanges"][0]["CidrIp"] == cidr_ip:
                     return True
             return False
         except botocore.exceptions.ClientError as e:
             raise AWSException("There was an error describing the security group: %s" %
                                e.response["Error"]["Message"])
 
-    def authorize_security_group_ingress(self, security_group_id, port, description):
+    def authorize_security_group_ingress(self, security_group_id, cidr_ip, port, description):
         try:
             client = boto3.client('ec2',
                                   aws_access_key_id=self.access_key_id,
@@ -403,7 +404,7 @@ class AWS:
                     {'IpProtocol': 'tcp',
                      'FromPort': port,
                      'ToPort': port,
-                     'IpRanges': [{'CidrIp': '0.0.0.0/0',
+                     'IpRanges': [{'CidrIp': cidr_ip,
                                    'Description': description}]}
                 ]
             )

--- a/spark_notebook/config.py
+++ b/spark_notebook/config.py
@@ -13,8 +13,7 @@ default_config = {
         "worker-count": 1,
         "region": "us-east-1",
         "instance-type": "r4.2xlarge",
-        "spot-price": 1.0,
-        "open-firewall": True
+        "spot-price": 1.0
     },
     "jupyter": {
         "password": "change-me-321"

--- a/spark_notebook/server.py
+++ b/spark_notebook/server.py
@@ -299,8 +299,8 @@ def cluster_details(account, cluster_id):
             cidr_ip = requests.get('http://ip.42.pl/raw').text + "/32"
 
             # Check and open SSH port
-            if not cloud_account.get_security_group_port_open(master_security_group, cidr_ip, 22):
-                cloud_account.authorize_security_group_ingress(master_security_group, cidr_ip, 22,
+            if not cloud_account.get_security_group_port_open(master_security_group, "0.0.0.0/0", 22):
+                cloud_account.authorize_security_group_ingress(master_security_group, "0.0.0.0/0", 22,
                                                                "SSH")
             # Check and open YARN ResourceManager port
             if not cloud_account.get_security_group_port_open(master_security_group, cidr_ip, 8088):

--- a/spark_notebook/server.py
+++ b/spark_notebook/server.py
@@ -299,9 +299,10 @@ def cluster_details(account, cluster_id):
             cidr_ip = requests.get('http://ip.42.pl/raw').text + "/32"
 
             # Check and open SSH port
-            if not cloud_account.get_security_group_port_open(master_security_group, "0.0.0.0/0", 22):
-                cloud_account.authorize_security_group_ingress(master_security_group, "0.0.0.0/0", 22,
-                                                               "SSH")
+            if not cloud_account.get_security_group_port_open(master_security_group, "0.0.0.0/0",
+                                                              22):
+                cloud_account.authorize_security_group_ingress(master_security_group, "0.0.0.0/0",
+                                                               22, "SSH")
             # Check and open YARN ResourceManager port
             if not cloud_account.get_security_group_port_open(master_security_group, cidr_ip, 8088):
                 cloud_account.authorize_security_group_ingress(master_security_group, cidr_ip, 8088,

--- a/tests/fake_boto.py
+++ b/tests/fake_boto.py
@@ -103,14 +103,17 @@ class FakeBotoClient(object):
                         {
                             "FromPort": 22,
                             "ToPort": 22,
+                            'IpRanges': [{'CidrIp': "0.0.0.0/32"}]
                         },
                         {
                             "FromPort": 8088,
                             "ToPort": 8088,
+                            'IpRanges': [{'CidrIp': "0.0.0.0/32"}]
                         },
                         {
                             "FromPort": 8888,
                             "ToPort": 8888,
+                            'IpRanges': [{'CidrIp': "0.0.0.0/32"}]
                         },
                     ]
                 }


### PR DESCRIPTION
* Deprecated the "open-firewall" config option
* When a user creates a new EMR cluster their public IP address (resolved by http://ip.42.pl/raw) is added to the firewall for ports 8888, 8088 and 18080. 
* If a user go to cluster detail page (http://localhost:5000/g/account-name/j-CLUSTERID), their public IP address will be added to the firewall for ports 8888, 8088 and 18080, if it doesn't already exist. The user doesn't have to be the person who created the EMR cluster, they just need permissions to view the EMR cluster details and to create new firewall rules.
